### PR TITLE
Fix `opts.type` undefined

### DIFF
--- a/cockpit/modules/core/Cockpit/assets/components.js
+++ b/cockpit/modules/core/Cockpit/assets/components.js
@@ -231,7 +231,7 @@ riot.tag2('cp-field', '', '', '', function(opts) {
                 var container = App.$('<div name="fieldcontainer" type="{ field.type }"></div>').appendTo(this.root);
 
                 var field   = typeof(opts.field) == 'string' ? {type:opts.field} : ( opts.field || {}),
-                    type    = field.type || 'text',
+                    type    = field.options.type || field.type || 'text',
                     options = field.options || {},
                     fc      = 'field-'+type;
 
@@ -245,6 +245,10 @@ riot.tag2('cp-field', '', '', '', function(opts) {
 
                 if (opts.bind) {
                     container[0].setAttribute('bind', opts.bind);
+                }
+
+                if (fc === 'field-text') {
+                    container[0].setAttribute('type', type);
                 }
 
                 riot.mount(container[0], fc, options);

--- a/cockpit/modules/core/Cockpit/assets/components/cp-components.tag
+++ b/cockpit/modules/core/Cockpit/assets/components/cp-components.tag
@@ -13,7 +13,7 @@
                 var container = App.$('<div name="fieldcontainer" type="{ field.type }"></div>').appendTo(this.root);
 
                 var field   = typeof(opts.field) == 'string' ? {type:opts.field} : ( opts.field || {}),
-                    type    = field.type || 'text',
+                    type    = field.options.type || field.type || 'text',
                     options = field.options || {},
                     fc      = 'field-'+type;
 
@@ -27,6 +27,10 @@
 
                 if (opts.bind) {
                     container[0].setAttribute('bind', opts.bind);
+                }
+
+                if (fc === 'field-text') {
+                    container[0].setAttribute('type', type);
                 }
 
                 riot.mount(container[0], fc, options);


### PR DESCRIPTION
When creating `cp-field` of type `TEXT`, `cp-field` should set `type`
attribute on container for riot to create `opts.type` variable.

Otherway the `type="{opts.type ||\'text\'}"` on riot template has no
effect at all.
